### PR TITLE
Fix/hide events without time

### DIFF
--- a/renderer/components/ActivitiesSection.tsx
+++ b/renderer/components/ActivitiesSection.tsx
@@ -12,12 +12,14 @@ import {
   padStringToMinutes,
 } from "../utils/datetime-ui";
 import GoogleCalendarEventsMessage from "./google-calendar/GoogleCalendarEventsMessage";
+import { googleCalendarEventsParsing } from "./google-calendar/GoogleCalendarEventsParsing";
 
 type ActivitiesSectionProps = {
   activities: Array<ReportActivity>;
   onEditActivity: (activity: ReportActivity | "new") => void;
   onDeleteActivity: (id: number) => void;
   selectedDate: Date;
+  availableProjects: Array<string>;
 };
 
 type PlaceholderProps = {
@@ -30,6 +32,7 @@ export default function ActivitiesSection({
   activities,
   onDeleteActivity,
   selectedDate,
+  availableProjects,
 }: ActivitiesSectionProps) {
   const [backgroundError, setBackgroundError] = useState("");
   const [renderError, setRenderError] = useState<RenderError>({
@@ -81,13 +84,17 @@ export default function ActivitiesSection({
         const from = getTimeFromGoogleObj(start.dateTime);
         const to = getTimeFromGoogleObj(end.dateTime);
 
+        googleEvent = googleCalendarEventsParsing(
+          googleEvent,
+          availableProjects
+        );
         return {
           from: from,
           to: to,
           duration: calcDurationBetweenTimes(from, to),
           project: googleEvent.project || "",
           activity: googleEvent.activity || "",
-          description: googleEvent.summary || "",
+          description: googleEvent.description || "",
           isValid: true,
           calendarId: googleEvent.id,
         };

--- a/renderer/components/ActivitiesSection.tsx
+++ b/renderer/components/ActivitiesSection.tsx
@@ -53,7 +53,15 @@ export default function ActivitiesSection({
     if (showGoogleEvents === false) setFormattedGoogleEvents([]);
 
     const formattedEvents = googleEvents
-      .filter((googleEvent) => !googleEvent?.isAdded)
+      .filter((googleEvent) => {
+        if (
+          googleEvent?.start?.dateTime &&
+          googleEvent?.end?.dateTime &&
+          !googleEvent?.isAdded
+        ) {
+          return googleEvent;
+        }
+      })
       .map((googleEvent) => {
         const { start, end } = googleEvent;
         const from = getTimeFromGoogleObj(start.dateTime);

--- a/renderer/components/ActivitiesSection.tsx
+++ b/renderer/components/ActivitiesSection.tsx
@@ -7,7 +7,7 @@ import { PlusIcon } from "@heroicons/react/24/solid";
 import { useGoogleCalendarStore } from "../store/googleCalendarStore";
 import { calcDurationBetweenTimes } from "../utils/reports";
 import { checkIsToday, getTimeFromGoogleObj } from "../utils/datetime-ui";
-import GoogleCalendarShowCheckbox from "./google-calendar/GoogleCalendarShowCheckbox";
+import GoogleCalendarEventsMessage from "./google-calendar/GoogleCalendarEventsMessage";
 
 type ActivitiesSectionProps = {
   activities: Array<ReportActivity>;
@@ -36,6 +36,9 @@ export default function ActivitiesSection({
   const [showGoogleEvents, setShowGoogleEvents] = useState(false);
   const [formattedGoogleEvents, setFormattedGoogleEvents] = useState([]);
   const today = checkIsToday(selectedDate);
+  const showGoogleEVentsTip = JSON.parse(
+    localStorage.getItem("showGoogleEvents")
+  );
 
   const keydownHandler = (e: KeyboardEvent) => {
     if (e.code === "Space" && e.ctrlKey) {
@@ -150,8 +153,8 @@ export default function ActivitiesSection({
       </div>
 
       <div className="flex gap-2 px-6 pb-4 items-center justify-end mr-auto">
-        {today && isLogged && (
-          <GoogleCalendarShowCheckbox
+        {today && isLogged && showGoogleEVentsTip && (
+          <GoogleCalendarEventsMessage
             setShowGoogleEvents={setShowGoogleEvents}
           />
         )}

--- a/renderer/components/ActivitiesTable.tsx
+++ b/renderer/components/ActivitiesTable.tsx
@@ -151,16 +151,11 @@ export default function ActivitiesTable({
         {tableActivities.map((activity, i) => (
           <tr
             key={i}
-            className={clsx(
-              `border-b border-gray-200 ${
-                activity.calendarId ? "bg-gray-100" : ""
-              }`,
-              {
-                "border-dashed border-b-2 border-gray-200":
-                  tableActivities[i].to != tableActivities[i + 1]?.from &&
-                  i + 1 !== tableActivities.length,
-              }
-            )}
+            className={clsx(`border-b border-gray-200 `, {
+              "border-dashed border-b-2 border-gray-200":
+                tableActivities[i].to != tableActivities[i + 1]?.from &&
+                i + 1 !== tableActivities.length,
+            })}
           >
             <td className="py-4 px-3 text-sm text-gray-500 whitespace-nowrap">
               <span

--- a/renderer/components/TrackTimeModal/TrackTimeModal.tsx
+++ b/renderer/components/TrackTimeModal/TrackTimeModal.tsx
@@ -175,11 +175,20 @@ export default function TrackTimeModal({
         editedActivity
       );
 
+      const arrayWithPrefilledValue = arrayWithMarkedActivty.map((gEvent) => {
+        if (gEvent.summary === editedActivity.description) {
+          if (project) gEvent.project = project;
+          if (activity) gEvent.activity = activity;
+        }
+
+        return gEvent;
+      });
+
       localStorage.setItem(
         "googleEvents",
-        JSON.stringify(arrayWithMarkedActivty)
+        JSON.stringify(arrayWithPrefilledValue)
       );
-      setGoogleEvents(arrayWithMarkedActivty);
+      setGoogleEvents(arrayWithPrefilledValue);
     }
 
     close();

--- a/renderer/components/google-calendar/GoogleCalendarAddEventBtn.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarAddEventBtn.tsx
@@ -8,6 +8,7 @@ import {
   updateGoogleCredentials,
 } from "../../API/googleCalendarAPI";
 import { checkAlreadyAddedGoogleEvents } from "../../utils/utils";
+import { googleCalendarEventsParsing } from "./GoogleCalendarEventsParsing";
 
 export type Event = {
   from: {
@@ -100,32 +101,7 @@ export default function GoogleCalendarAddEventBtn({
         event.from = from;
         event.to = to;
 
-        const items = summary ? summary.split(" - ") : "";
-
-        switch (items.length) {
-          case 0:
-            event.description = "";
-            break;
-          case 1:
-            event.description = items[0];
-            break;
-          case 2:
-            if (availableProjects.includes(items[0])) {
-              event.project = items[0];
-              event.description = items[1];
-            } else {
-              event.activity = items[0];
-              event.description = items[1];
-            }
-            break;
-          case 3:
-            event.project = items[0];
-            event.activity = items[1];
-            event.description = items[2];
-            break;
-          default:
-            event.description = items.join(" - ");
-        }
+        event = googleCalendarEventsParsing(event, availableProjects);
 
         return (
           <div className="" key={id}>

--- a/renderer/components/google-calendar/GoogleCalendarAddEventBtn.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarAddEventBtn.tsx
@@ -53,8 +53,12 @@ export default function GoogleCalendarAddEventBtn({
         data?.items
       );
 
+      const filteredGoogleEventsWithoutTime = checkedGoogleEvents.filter(
+        (gEvent) => gEvent?.start?.dateTime || gEvent?.end?.dateTime
+      );
+
       localStorage.setItem("googleEvents", JSON.stringify(checkedGoogleEvents));
-      setGoogleEvents(checkedGoogleEvents);
+      setGoogleEvents(filteredGoogleEventsWithoutTime);
     } catch (error) {
       setIsError(true);
       console.error(error);
@@ -119,7 +123,7 @@ export default function GoogleCalendarAddEventBtn({
             event.activity = items[1];
             event.description = items[2];
             break;
-            default:
+          default:
             event.description = items.join(" - ");
         }
 

--- a/renderer/components/google-calendar/GoogleCalendarAuth.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarAuth.tsx
@@ -23,6 +23,7 @@ function GoogleCalendarAuth() {
     localStorage.removeItem("googleAccessToken");
     localStorage.removeItem("googleRefreshToken");
     localStorage.removeItem("googleEvents");
+    localStorage.setItem("showGoogleEvents", false.toString());
     setIsLogged(false);
     router.push("/settings");
   };

--- a/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
@@ -6,10 +6,11 @@ import {
 } from "../../API/googleCalendarAPI";
 import { checkAlreadyAddedGoogleEvents } from "../../utils/utils";
 import Loader from "../ui/Loader";
+import { ReportActivity } from "../../utils/reports";
 
 type GoogleCalendarEventsMessageProps = {
   setShowGoogleEvents: Dispatch<SetStateAction<Boolean>>;
-  formattedGoogleEvents: Report[];
+  formattedGoogleEvents: ReportActivity[];
 };
 
 export default function GoogleCalendarEventsMessage({

--- a/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState, Dispatch, SetStateAction } from "react";
+import { useGoogleCalendarStore } from "../../store/googleCalendarStore";
+import {
+  getGoogleEvents,
+  updateGoogleCredentials,
+} from "../../API/googleCalendarAPI";
+import { checkAlreadyAddedGoogleEvents } from "../../utils/utils";
+import Loader from "../ui/Loader";
+
+type GoogleCalendarEventsMessageProps = {
+  setShowGoogleEvents: Dispatch<SetStateAction<Boolean>>;
+};
+
+export default function GoogleCalendarEventsMessage({
+  setShowGoogleEvents,
+}: GoogleCalendarEventsMessageProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const { googleEvents, setGoogleEvents } = useGoogleCalendarStore();
+
+  const loadGoogleEvents = async (gToken: string) => {
+    try {
+      setIsLoading(true);
+      const data = await getGoogleEvents(gToken);
+
+      // detect expired token
+      if (data?.error && data?.error?.code === 401) {
+        const refreshToken = localStorage.getItem("googleRefreshToken");
+        const updatedCredentials = await updateGoogleCredentials(refreshToken);
+        const newAccessToken = updatedCredentials?.access_token;
+        localStorage.setItem("googleAccessToken", newAccessToken);
+        loadGoogleEvents(newAccessToken);
+        return;
+      }
+
+      const lsGoogleEvents = JSON.parse(localStorage.getItem("googleEvents"));
+
+      if (lsGoogleEvents === null) {
+        localStorage.setItem("googleEvents", JSON.stringify(data?.items));
+        setShowGoogleEvents(true);
+        setGoogleEvents(data?.items);
+        return;
+      }
+
+      const checkedGoogleEvents = checkAlreadyAddedGoogleEvents(
+        lsGoogleEvents,
+        data?.items
+      );
+
+      localStorage.setItem("googleEvents", JSON.stringify(checkedGoogleEvents));
+      setGoogleEvents(checkedGoogleEvents);
+      setShowGoogleEvents(true);
+    } catch (error) {
+      setIsError(true);
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const googleAccessToken = localStorage.getItem("googleAccessToken");
+    const showGoogleEvents = localStorage.getItem("showGoogleEvents");
+
+    if (googleAccessToken && showGoogleEvents === "true") {
+      loadGoogleEvents(googleAccessToken);
+
+      global.ipcRenderer.on("window-restored", () => {
+        loadGoogleEvents(googleAccessToken);
+      });
+    }
+
+    return () => {
+      global.ipcRenderer.removeAllListeners("window-restored");
+    };
+  }, []);
+
+  const resetGoogleEventsHandle = () => {
+    const resetedGoogleEvents = googleEvents.map((gEvent) => {
+      gEvent.isAdded = false;
+
+      return gEvent;
+    });
+
+    localStorage.setItem("googleEvents", JSON.stringify(resetedGoogleEvents));
+    setGoogleEvents(resetedGoogleEvents);
+    setShowGoogleEvents(false);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center pr-14">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-gray-500">
+        Something went wrong while getting events
+      </p>
+    );
+  }
+
+  if (googleEvents?.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">You don't have events for today</p>
+    );
+  }
+
+  if (
+    googleEvents?.length > 0 &&
+    googleEvents.every((gEvent) => {
+      return gEvent?.isAdded || !gEvent?.start?.dateTime;
+    })
+  ) {
+    return (
+      <>
+        <p className="text-sm text-gray-500">
+          You've already added all events for today
+        </p>
+        <button
+          onClick={resetGoogleEventsHandle}
+          className="text-gray-500 inline-flex items-center justify-center px-2 py-1 text-xs border rounded-md shadow-sm hover:bg-gray-100 "
+        >
+          reset
+        </button>
+      </>
+    );
+  }
+
+  if (googleEvents?.length > 0) {
+    return (
+      <>
+        <p className="text-sm text-gray-500">Google events are showing</p>
+      </>
+    );
+  }
+}

--- a/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
+++ b/renderer/components/google-calendar/GoogleCalendarEventsMessage.tsx
@@ -9,10 +9,12 @@ import Loader from "../ui/Loader";
 
 type GoogleCalendarEventsMessageProps = {
   setShowGoogleEvents: Dispatch<SetStateAction<Boolean>>;
+  formattedGoogleEvents: Report[];
 };
 
 export default function GoogleCalendarEventsMessage({
   setShowGoogleEvents,
+  formattedGoogleEvents,
 }: GoogleCalendarEventsMessageProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -84,7 +86,6 @@ export default function GoogleCalendarEventsMessage({
 
     localStorage.setItem("googleEvents", JSON.stringify(resetedGoogleEvents));
     setGoogleEvents(resetedGoogleEvents);
-    setShowGoogleEvents(false);
   };
 
   if (isLoading) {
@@ -127,6 +128,35 @@ export default function GoogleCalendarEventsMessage({
           reset
         </button>
       </>
+    );
+  }
+
+  if (
+    formattedGoogleEvents.length <
+      googleEvents.filter((gEvent) => !gEvent.isAdded).length &&
+    formattedGoogleEvents.length !== 0
+  ) {
+    return (
+      <p className="text-sm text-gray-500">
+        Google events are showing. Skipped{" "}
+        {googleEvents.filter((gEvent) => !gEvent.isAdded).length -
+          formattedGoogleEvents.length}{" "}
+        event(s)
+      </p>
+    );
+  }
+
+  if (
+    formattedGoogleEvents?.length === 0 &&
+    !googleEvents.every((gEvent) => {
+      return gEvent?.isAdded || !gEvent?.start?.dateTime;
+    })
+  ) {
+    return (
+      <p className="text-sm text-gray-500">
+        Skipped {googleEvents.filter((gEvent) => !gEvent?.isAdded)?.length}{" "}
+        event(s)
+      </p>
     );
   }
 

--- a/renderer/components/google-calendar/GoogleCalendarEventsParsing.ts
+++ b/renderer/components/google-calendar/GoogleCalendarEventsParsing.ts
@@ -1,0 +1,57 @@
+type GoogleEvent = {
+  created: string;
+  creator: { email: string; self: boolean };
+  description: string;
+  end: { dateTime: string; timeZone: string };
+  etag: string;
+  eventType: string;
+  htmlLink: URL;
+  iCalUID: string;
+  id: string;
+  kind: string;
+  organizer: { email: string; self: true };
+  reminders: { useDefault: boolean };
+  sequence: number;
+  start: { dateTime: string; timeZone: string };
+  status: string;
+  summary: string;
+  updated: string;
+  from: { date: string; time: string };
+  to: { date: string; time: string };
+  isAdded?: boolean;
+  project?: string;
+  activity?: string;
+};
+export function googleCalendarEventsParsing(googleEvent:GoogleEvent, availableProjects:Array<string>){
+
+    const { summary } = googleEvent;
+    const items = summary ? summary.split(" - ") : "";
+
+    switch (items.length) {
+        case 0:
+        googleEvent.description = "";
+        break;
+        case 1:
+        googleEvent.description = items[0];
+        break;
+        case 2:
+        if (availableProjects.includes(items[0])) {
+            googleEvent.project = items[0];
+            googleEvent.description = items[1];
+        } else {
+        googleEvent.activity = items[0];
+        googleEvent.description = items[1];
+        }
+        break;
+        case 3:
+        googleEvent.project = items[0];
+        googleEvent.activity = items[1];
+        googleEvent.description = items[2];
+        break;
+        default:
+        if(items){
+        googleEvent.description = items.join(" - ");}
+    }
+    return googleEvent;
+
+}

--- a/renderer/pages/index.tsx
+++ b/renderer/pages/index.tsx
@@ -350,6 +350,9 @@ export default function Home() {
                       onEditActivity={setTrackTimeModalActivity}
                       onDeleteActivity={onDeleteActivity}
                       selectedDate={selectedDate}
+                      availableProjects={
+                        latestProjAndAct ? Object.keys(latestProjAndAct) : []
+                      }
                     />
                   </div>
                 </section>

--- a/renderer/pages/settings.tsx
+++ b/renderer/pages/settings.tsx
@@ -39,6 +39,7 @@ const SettingsPage = () => {
   );
   const { isLogged, googleUsername, googleEvents, setGoogleEvents } =
     useGoogleCalendarStore();
+  const [showGoogleEvents, setShowGoogleEvents] = useState(false);
 
   const handleSignInTrelloButton = () => {
     const trelloAuthUrl = getTrelloAuthUrl({
@@ -55,16 +56,18 @@ const SettingsPage = () => {
     router.push("/settings");
   };
 
-  const resetGoogleEventsHandle = () => {
-    const resetedGoogleEvents = googleEvents.map((gEvent) => {
-      gEvent.isAdded = false;
-
-      return gEvent;
-    });
-
-    localStorage.setItem("googleEvents", JSON.stringify(resetedGoogleEvents));
-    setGoogleEvents(resetedGoogleEvents);
+  const handleCheckboxChange = () => {
+    setShowGoogleEvents((prev) => !prev);
+    const reversShowGoogleEvents = !showGoogleEvents;
+    localStorage.setItem("showGoogleEvents", reversShowGoogleEvents.toString());
   };
+
+  useEffect(() => {
+    const lsShowGoogleEvents = localStorage.getItem("showGoogleEvents");
+    if (lsShowGoogleEvents === "true") {
+      setShowGoogleEvents(true);
+    }
+  }, []);
 
   useEffect(() => {
     if (window.location.hash.includes("token")) {
@@ -209,20 +212,19 @@ const SettingsPage = () => {
               <GoogleCalendarAuth />
             </div>
 
-            {isLogged && googleEvents.length > 0 && (
+            {isLogged && (
               <div className="flex items-start justify-between gap-6">
-                <p className=" max-w-lg text-sm text-gray-500">
-                  Make all Google events visible again. This can be useful when
-                  you have added an event and accidentally deleted it manually
+                <p className=" max-w-sm text-sm text-gray-500">
+                  Show google events in activity table
                 </p>
-                <Tooltip tooltipText="reseted">
-                  <button
-                    onClick={resetGoogleEventsHandle}
-                    className="text-gray-500 inline-flex items-center justify-center px-2 py-1 text-xs border rounded-md shadow-sm hover:bg-gray-100 "
-                  >
-                    reset
-                  </button>
-                </Tooltip>
+                <div>
+                  <input
+                    onChange={handleCheckboxChange}
+                    className="w-4 h-4"
+                    type="checkbox"
+                    checked={showGoogleEvents}
+                  ></input>
+                </div>
               </div>
             )}
           </div>

--- a/renderer/pages/settings.tsx
+++ b/renderer/pages/settings.tsx
@@ -56,6 +56,17 @@ const SettingsPage = () => {
     router.push("/settings");
   };
 
+  const resetGoogleEventsHandle = () => {
+    const resetedGoogleEvents = googleEvents.map((gEvent) => {
+      gEvent.isAdded = false;
+
+      return gEvent;
+    });
+
+    localStorage.setItem("googleEvents", JSON.stringify(resetedGoogleEvents));
+    setGoogleEvents(resetedGoogleEvents);
+  };
+
   const handleCheckboxChange = () => {
     setShowGoogleEvents((prev) => !prev);
     const reversShowGoogleEvents = !showGoogleEvents;
@@ -225,6 +236,23 @@ const SettingsPage = () => {
                     checked={showGoogleEvents}
                   ></input>
                 </div>
+              </div>
+            )}
+
+            {isLogged && googleEvents.length > 0 && (
+              <div className="flex items-start justify-between gap-6">
+                <p className=" max-w-lg text-sm text-gray-500">
+                  Make all Google events visible again. This can be useful when
+                  you have added an event and accidentally deleted it manually
+                </p>
+                <Tooltip tooltipText="reseted">
+                  <button
+                    onClick={resetGoogleEventsHandle}
+                    className="text-gray-500 inline-flex items-center justify-center px-2 py-1 text-xs border rounded-md shadow-sm hover:bg-gray-100 "
+                  >
+                    reset
+                  </button>
+                </Tooltip>
               </div>
             )}
           </div>

--- a/renderer/store/googleCalendarStore.ts
+++ b/renderer/store/googleCalendarStore.ts
@@ -21,6 +21,8 @@ export type GoogleEvent = {
   from: { date: string; time: string };
   to: { date: string; time: string };
   isAdded?: boolean;
+  project?: string;
+  activity?: string;
 };
 
 type googleCalendarStoreProps = {

--- a/renderer/utils/datetime-ui.ts
+++ b/renderer/utils/datetime-ui.ts
@@ -80,3 +80,10 @@ export const getTimeFromGoogleObj = (date: string) => {
     hour12: false,
   });
 };
+
+export const padStringToMinutes = (timeString: string) => {
+  if (!timeString) return;
+
+  const [hours, minutes] = timeString.split(":").map(Number);
+  return hours * 60 + minutes;
+};

--- a/renderer/utils/utils.ts
+++ b/renderer/utils/utils.ts
@@ -22,8 +22,8 @@ export const checkAlreadyAddedGoogleEvents = (
       newEvent.isAdded = false;
     }
 
-    if (originalEvent.project) newEvent.project = originalEvent.project;
-    if (originalEvent.activity) newEvent.activity = originalEvent.activity;
+    if (originalEvent?.project) newEvent.project = originalEvent.project;
+    if (originalEvent?.activity) newEvent.activity = originalEvent.activity;
 
     return newEvent;
   });

--- a/renderer/utils/utils.ts
+++ b/renderer/utils/utils.ts
@@ -22,6 +22,9 @@ export const checkAlreadyAddedGoogleEvents = (
       newEvent.isAdded = false;
     }
 
+    if (originalEvent.project) newEvent.project = originalEvent.project;
+    if (originalEvent.activity) newEvent.activity = originalEvent.activity;
+
     return newEvent;
   });
 };


### PR DESCRIPTION
work with feedback:
- moved checkbox that showed events to setting page
- the event has transparent background
- event displayed till it is not covered by time registration
- user adds event and set project or activity -> next event with the same title displayed with the project and activity