### PR TITLE
FEATURE: add daysOff hours to week hours and timeBadge

### DIFF
--- a/renderer/src/components/Calendar/Calendar.tsx
+++ b/renderer/src/components/Calendar/Calendar.tsx
@@ -308,6 +308,7 @@ export const Calendar = ({
       <FullCalendarWrapper
         setSelectedDate={setSelectedDate}
         selectedDate={selectedDate}
+        calendarDate={calendarDate}
         formattedQuarterReports={formattedQuarterReports}
         weekNumberRef={weekNumberRef}
         daysOff={daysOff}

--- a/renderer/src/components/Calendar/FullCalendarWrapper.tsx
+++ b/renderer/src/components/Calendar/FullCalendarWrapper.tsx
@@ -4,9 +4,7 @@ import { formatDuration } from "@/helpers/utils/reports";
 import { DatePointApi, DayCellContentArg, EventContentArg, WeekNumberContentArg } from "@fullcalendar/core";
 import { CalendarDaysIcon, FaceFrownIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
 import { ExclamationCircleIcon } from "@heroicons/react/24/solid";
-import { DayOff, FormattedReport, FullCalendarWrapperProps } from "./types";
-
-type daysOffAccumulatorType = { numberedDays: string[]; hours: number };
+import { DayOff, FormattedReport, FullCalendarWrapperProps, daysOffAccumulatorType } from "./types";
 
 const FullCalendarWrapper = ({
   children,

--- a/renderer/src/components/Calendar/types.ts
+++ b/renderer/src/components/Calendar/types.ts
@@ -56,6 +56,7 @@ export type VacationSickDaysData = {
 
 export type FullCalendarWrapperProps = {
   children: ReactElement;
+  calendarDate: Date;
   selectedDate: Date;
   setSelectedDate: Dispatch<SetStateAction<Date>>;
   daysOff: DayOff[];

--- a/renderer/src/components/Calendar/types.ts
+++ b/renderer/src/components/Calendar/types.ts
@@ -63,3 +63,5 @@ export type FullCalendarWrapperProps = {
   formattedQuarterReports: FormattedReport[];
   weekNumberRef: MutableRefObject<any>;
 };
+
+export type daysOffAccumulatorType = { numberedDays: string[]; hours: number };

--- a/renderer/src/helpers/utils/datetime-ui.ts
+++ b/renderer/src/helpers/utils/datetime-ui.ts
@@ -31,13 +31,16 @@ export function isTheSameDates(date1: Date, date2: Date): boolean {
 
   return firstDate.setHours(0, 0, 0, 0) === socondDate.setHours(0, 0, 0, 0);
 }
+function isLeapYear(year: number) {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
 
 export function getWeekNumber(dateString: string) {
   const dateObj = getDateFromString(dateString);
   const startOfYear = new Date(dateObj.getFullYear(), 0, 1);
   const days = Math.floor((dateObj.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000));
   const year = dateObj.getFullYear();
-  const leapYearDay = year === 2020 || year === 2024 || year === 2028 || year === 2032 ? 0 : 1;
+  const leapYearDay = isLeapYear(year) ? 0 : 1;
 
   return Math.ceil((days + startOfYear.getDay() + leapYearDay) / 7);
 }

--- a/renderer/src/helpers/utils/datetime-ui.ts
+++ b/renderer/src/helpers/utils/datetime-ui.ts
@@ -36,8 +36,10 @@ export function getWeekNumber(dateString: string) {
   const dateObj = getDateFromString(dateString);
   const startOfYear = new Date(dateObj.getFullYear(), 0, 1);
   const days = Math.floor((dateObj.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000));
+  const year = dateObj.getFullYear();
+  const leapYearDay = year === 2020 || year === 2024 || year === 2028 || year === 2032 ? 0 : 1;
 
-  return Math.ceil((days + startOfYear.getDay()) / 7);
+  return Math.ceil((days + startOfYear.getDay() + leapYearDay) / 7);
 }
 
 export function getDateFromString(dateString: string) {

--- a/renderer/src/shared/TimeBadge/TimeBadge.tsx
+++ b/renderer/src/shared/TimeBadge/TimeBadge.tsx
@@ -1,14 +1,32 @@
-import React from "react";
+import { useState, useEffect } from "react";
 import { stringToMinutes } from "@/helpers/utils/utils";
 import { TimeBadgeProps } from "./types";
+import { loadHolidaysAndVacations } from "@/components/Calendar/utils";
 
 export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeProps) {
   const curDate = new Date();
   const curTime = curDate.getHours() * 60 + curDate.getMinutes();
+  const [dayOffDuration, setDayOffDuration] = useState(0);
+
+  useEffect(() => {
+    setDayOffDuration(0);
+    (async () => {
+      const daysOff = await loadHolidaysAndVacations(selectedDate);
+      daysOff.forEach((day) => {
+        if (
+          day.date.getDate() === selectedDate.getDate() &&
+          day.date.getMonth() === selectedDate.getMonth() &&
+          day.date.getFullYear() === selectedDate.getFullYear()
+        ) {
+          setDayOffDuration(Number(day.duration));
+        }
+      });
+    })();
+  }, [selectedDate, hours]);
 
   if (
-    (hours < 6 && selectedDate.toDateString() !== curDate.toDateString()) ||
-    (hours < 6 && curTime - stringToMinutes(startTime) > 360)
+    (hours + dayOffDuration < 6 && selectedDate.toDateString() !== curDate.toDateString()) ||
+    (hours + dayOffDuration < 6 && curTime - stringToMinutes(startTime) > 360)
   ) {
     return (
       <span
@@ -20,8 +38,8 @@ export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeP
     );
   }
   if (
-    (hours < 8 && selectedDate.toLocaleDateString() !== curDate.toLocaleDateString()) ||
-    (hours < 8 && curTime - stringToMinutes(startTime) > 480)
+    (hours + dayOffDuration < 8 && selectedDate.toLocaleDateString() !== curDate.toLocaleDateString()) ||
+    (hours + dayOffDuration < 8 && curTime - stringToMinutes(startTime) > 480)
   ) {
     return (
       <span

--- a/renderer/src/shared/TimeBadge/TimeBadge.tsx
+++ b/renderer/src/shared/TimeBadge/TimeBadge.tsx
@@ -3,6 +3,7 @@ import { stringToMinutes } from "@/helpers/utils/utils";
 import { TimeBadgeProps } from "./types";
 import { loadHolidaysAndVacations } from "@/components/Calendar/utils";
 import { DayOff } from "@/components/Calendar/types";
+import { SIX_HOURS, SIX_HOURS_IN_MINUTES, EIGHT_HOURS, EIGHT_HOURS_IN_MINUTES } from "./constants";
 
 export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeProps) {
   const curDate = new Date();
@@ -26,28 +27,28 @@ export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeP
   }, [selectedDate, hours]);
 
   if (
-    (hours + dayOffDuration < 6 && selectedDate.toDateString() !== curDate.toDateString()) ||
-    (hours + dayOffDuration < 6 && curTime - stringToMinutes(startTime) > 360)
+    (hours + dayOffDuration < SIX_HOURS && selectedDate.toDateString() !== curDate.toDateString()) ||
+    (hours + dayOffDuration < SIX_HOURS && curTime - stringToMinutes(startTime) > SIX_HOURS_IN_MINUTES)
   ) {
     return (
       <span
         data-testid="sixHoursBadge"
         className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:text-red-400 dark:bg-red-400/20"
       >
-        less than 6h
+        less than {SIX_HOURS}h
       </span>
     );
   }
   if (
-    (hours + dayOffDuration < 8 && selectedDate.toLocaleDateString() !== curDate.toLocaleDateString()) ||
-    (hours + dayOffDuration < 8 && curTime - stringToMinutes(startTime) > 480)
+    (hours + dayOffDuration < EIGHT_HOURS && selectedDate.toLocaleDateString() !== curDate.toLocaleDateString()) ||
+    (hours + dayOffDuration < EIGHT_HOURS && curTime - stringToMinutes(startTime) > EIGHT_HOURS_IN_MINUTES)
   ) {
     return (
       <span
         data-testid="eightHoursBadge"
         className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:text-yellow-400 dark:bg-yellow-400/20"
       >
-        less than 8h
+        less than {EIGHT_HOURS}h
       </span>
     );
   }

--- a/renderer/src/shared/TimeBadge/TimeBadge.tsx
+++ b/renderer/src/shared/TimeBadge/TimeBadge.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { stringToMinutes } from "@/helpers/utils/utils";
 import { TimeBadgeProps } from "./types";
 import { loadHolidaysAndVacations } from "@/components/Calendar/utils";
+import { DayOff } from "@/components/Calendar/types";
 
 export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeProps) {
   const curDate = new Date();
@@ -12,7 +13,7 @@ export default function TimeBadge({ hours, startTime, selectedDate }: TimeBadgeP
     setDayOffDuration(0);
     (async () => {
       const daysOff = await loadHolidaysAndVacations(selectedDate);
-      daysOff.forEach((day) => {
+      daysOff.forEach((day: DayOff) => {
         if (
           day.date.getDate() === selectedDate.getDate() &&
           day.date.getMonth() === selectedDate.getMonth() &&

--- a/renderer/src/shared/TimeBadge/constants.ts
+++ b/renderer/src/shared/TimeBadge/constants.ts
@@ -1,0 +1,4 @@
+export const SIX_HOURS = 6;
+export const SIX_HOURS_IN_MINUTES = SIX_HOURS * 60;
+export const EIGHT_HOURS = 8;
+export const EIGHT_HOURS_IN_MINUTES = EIGHT_HOURS * 60;


### PR DESCRIPTION
https://trello.com/c/hu4HNZ5R/361-add-sickness-and-vacation-in-total-hours-in-calendar
https://ukad.slack.com/archives/C069N5LUP3M/p1708697779970829
plus fixed weekday definition, getWeekNumber function was not working correctly for leap years